### PR TITLE
Loot events / Kill count

### DIFF
--- a/src/main/config.js
+++ b/src/main/config.js
@@ -16,6 +16,9 @@ const configStorage = new Store({
   sidebarStyle: {
     type: 'string',
   },
+  killCount: {
+    type: 'boolean',
+  },
   huntingSets: {
     type: 'array',
     items: {
@@ -34,6 +37,7 @@ const configStorage = new Store({
     returnPercent: { type: 'boolean' },
     numGlobals: { type: 'boolean' },
     numHofs: { type: 'boolean' },
+    killCount: { type: 'boolean' },
     hitPercent: { type: 'boolean' },
     evadePercent: { type: 'boolean' },
     sessionTime: { type: 'boolean' },

--- a/src/main/session.js
+++ b/src/main/session.js
@@ -6,6 +6,7 @@ const db = require('./database');
 
 class Session {
   static IGNORE_LOOT = ['Universal Ammo', 'Strongbox Key'];
+  static IGNORE_LOOT_EVENT_LOOT = ['Mayhem Token'];
 
   static async Load(id, instanceId = null) {
     const data = await (instanceId
@@ -173,7 +174,17 @@ class Session {
 
   saveLootEvent(updateDb = false) {
     clearTimeout(this.currentEventTimer);
-    if (this.currentLootEvent.length > 0) {
+    const lootSize = this.currentLootEvent.length;
+    if (lootSize > 0) {
+      const firstItemName = this.currentLootEvent[0]?.values?.name;
+
+      // Independent loot. Pick up, mission reward or similar.
+      if (lootSize === 1 && Session.IGNORE_LOOT_EVENT_LOOT.includes(firstItemName)) {
+        this.currentLootEvent = [];
+        this.lastLootTime = null;
+        return;
+      }
+
       const lootEventValue = this.currentLootEvent.reduce(
         (previous, current) => (previous + Number(current.values.value)),
         0,

--- a/src/main/session.js
+++ b/src/main/session.js
@@ -246,7 +246,7 @@ class Session {
 
       this.currentEventTimer = setTimeout(() => {
         this.saveLootEvent(true);
-      }, 500);
+      }, 1500);
     }
 
     this.aggregate('allLoot', null, value, amount);

--- a/src/main/session.js
+++ b/src/main/session.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const EventEmitter = require('events');
 const { v4: uuidv4 } = require('uuid');
 const db = require('./database');
 
@@ -94,6 +95,8 @@ class Session {
     this.lastLootTime = null;
     this.currentLootEvent = [];
     this.currentEventTimer = null;
+
+    this.emitter = new EventEmitter();
   }
 
   newEvent(eventData, updateDb = true) {
@@ -188,6 +191,7 @@ class Session {
 
     if (updateDb) {
       this.updateDb();
+      this.emitter.emit('session-updated');
     }
   }
 

--- a/src/overlay/overlay.jsx
+++ b/src/overlay/overlay.jsx
@@ -32,6 +32,7 @@ function sum(...values) {
 
 const Overlay = () => {
   const [settings, setSettings] = useState(null);
+  const [isKillCountEnabled, setIsKillCountEnabled] = useState(false);
   const [data, setData] = useState(null);
 
   function updateData(newData) {
@@ -74,6 +75,7 @@ const Overlay = () => {
       returnPercent: Number.isNaN(returnPercent) ? 0 : returnPercent,
       numGlobals: newData.aggregated?.globals?.count || 0,
       numHofs: newData.aggregated?.hofs?.count || 0,
+      numKills: newData.aggregated?.lootEvent?.count || 0,
       hitPercent: Number.isNaN(playerAttackHitRate) ? 0 : playerAttackHitRate,
       evadePercent: Number.isNaN(enemyAttackMissRate) ? 0 : enemyAttackMissRate,
       sessionTime: 500,
@@ -81,18 +83,18 @@ const Overlay = () => {
   }
 
   useEffect(() => {
+    const updateSettings = newSettings => {
+      setSettings(newSettings.overlay);
+      setIsKillCountEnabled(newSettings.killCount);
+    };
+
     window.api.on('instance-loaded', console.log);
     window.api.on('session-updated', updateData);
     window.api.on('session-data-updated', updateData);
-
-    window.api.on('settings-updated', newSettings => {
-      setSettings(newSettings.overlay);
-    });
+    window.api.on('settings-updated', updateSettings);
 
     window.api.get('active-session').then(updateData);
-    window.api.get('settings').then(newSettings => {
-      setSettings(newSettings.overlay);
-    });
+    window.api.get('settings').then(updateSettings);
   }, []);
 
   if (!settings || !data) {
@@ -108,6 +110,7 @@ const Overlay = () => {
     settings.numHofs,
     settings.hitPercent,
     settings.evadePercent,
+    settings.killCount && isKillCountEnabled,
   ].filter(value => Boolean(value)).length === 0;
 
   return (
@@ -157,6 +160,13 @@ const Overlay = () => {
         <div className="overlay__item overlay__numHofs">
           <div className="overlay__label">HoFs</div>
           <div className="overlay__value">{data.numHofs}</div>
+        </div>
+      )}
+
+      {isKillCountEnabled && settings.killCount && (
+        <div className="overlay__item overlay__killCount">
+          <div className="overlay__label">Kills</div>
+          <div className="overlay__value">{data.numKills}</div>
         </div>
       )}
 

--- a/src/render/components/overlay-settings.jsx
+++ b/src/render/components/overlay-settings.jsx
@@ -8,6 +8,7 @@ const OVERLAY_TOGGLES = [
   { label: 'Returns (%)', key: 'returnPercent', default: false },
   { label: 'Global count', key: 'numGlobals', default: false },
   { label: 'HoF count', key: 'numHofs', default: false },
+  { label: 'Kill count (requires \'Show kill count\' to be enabled)', key: 'killCount', default: false },
   { label: 'Hit rate (%)', key: 'hitPercent', default: false },
   { label: 'Evade rate (%)', key: 'evadePercent', default: false },
   // { label: 'Session time', key: 'sessionTime', default: false },

--- a/src/render/pages/hunting/current.jsx
+++ b/src/render/pages/hunting/current.jsx
@@ -12,6 +12,7 @@ import NotesView from '../../views/notes-view';
 const Current = () => {
   const [currentTab, setCurrentTab] = useState('loot');
   const [avatarName, setAvatarName] = useState('none');
+  const [killCountEnabled, setKillCountEnabled] = useState(false);
   const [huntingSets, setHuntingSets] = useState([]);
   const [activeHuntingSet, setActiveHuntingSet] = useState(null);
 
@@ -24,6 +25,7 @@ const Current = () => {
       setHuntingSets(settings?.huntingSets);
       setActiveHuntingSet(settings?.activeHuntingSet);
       setAvatarName(settings?.avatarName);
+      setKillCountEnabled(Boolean(settings?.killCount));
     };
 
     window.api.get('settings').then(updateSettings);
@@ -72,7 +74,7 @@ const Current = () => {
 
       {currentTab === 'loot' && <LootView />}
       {currentTab === 'skills' && <SkillView />}
-      {currentTab === 'stats' && <StatsView avatarName={avatarName} />}
+      {currentTab === 'stats' && <StatsView avatarName={avatarName} isKillCountEnabled={killCountEnabled} />}
       {currentTab === 'misc' && <MiscView />}
       {currentTab === 'calc' && <CalcView />}
       {currentTab === 'notes' && <NotesView />}

--- a/src/render/pages/settings.jsx
+++ b/src/render/pages/settings.jsx
@@ -63,7 +63,7 @@ const Settings = () => {
                   onChange={evt => updateSettings('killCount', evt.target.checked)}
                 />
                 {' '}
-                Show kill count (Could be inaccurate, based on loot events happening the same second)
+                Show kill count (May be inaccurate, looting multiple mobs at the same time or loot lag may skew results)
               </label>
             </div>
           </div>

--- a/src/render/pages/settings.jsx
+++ b/src/render/pages/settings.jsx
@@ -46,10 +46,27 @@ const Settings = () => {
               }
             }}
           />
+
           <AvatarName
             currentAvatarName={settings?.avatarName}
             updateAvatarName={avatarName => updateSettings('avatarName', avatarName)}
           />
+
+          <div className="box block">
+            <h3 className="title">Extras</h3>
+            <div className="control">
+              <label className="label">
+                <input
+                  type="checkbox"
+                  className="checkbox mr-2"
+                  checked={settings?.killCount ?? false}
+                  onChange={evt => updateSettings('killCount', evt.target.checked)}
+                />
+                {' '}
+                Show kill count (Could be inaccurate, based on loot events happening the same second)
+              </label>
+            </div>
+          </div>
 
           <HuntingSets huntingSets={settings.huntingSets} />
 

--- a/src/render/views/stats-view.jsx
+++ b/src/render/views/stats-view.jsx
@@ -8,7 +8,7 @@ function makeNumber(value) {
   return value || 0;
 }
 
-const StatsView = ({ avatarName }) => {
+const StatsView = ({ avatarName, isKillCountEnabled }) => {
   const [stats, setStats] = useState({});
 
   useEffect(() => {
@@ -47,6 +47,7 @@ const StatsView = ({ avatarName }) => {
         damageInflictedTotal: makeNumber(aggregated?.damageInflicted?.total),
         damageTakenTotal: makeNumber(aggregated?.damageTaken?.total),
         healAll: sortedHeal,
+        killCount: makeNumber(aggregated?.lootEvent?.count),
         damageInflictedCount,
         damageInflictedCritCount,
         damageTakenCritCount,
@@ -108,6 +109,14 @@ const StatsView = ({ avatarName }) => {
               value={stats?.damageInflictedCritCount?.toLocaleString() ?? 0}
             />
           </div>
+          {isKillCountEnabled && (
+            <div className="tile tile-toplevel">
+              <StatBox
+                title="Estimated kills"
+                value={stats?.killCount ?? 0}
+              />
+            </div>
+          )}
         </div>
       </div>
       <div className="content box info-box">
@@ -187,6 +196,7 @@ const StatsView = ({ avatarName }) => {
 
 StatsView.propTypes = {
   avatarName: PropTypes.string,
+  isKillCountEnabled: PropTypes.bool,
 };
 
 export default StatsView;


### PR DESCRIPTION
Fixes: https://github.com/EntropiaTally/entropia-tally-app/issues/17

Estimate kill counts / loot events by grouping them per 2 seconds.

Example aggregation
```json
{
    "lootEvent": {
        "count": 5,
        "total": 143.2,
        "avg": 28.639999999999997,
        "percent": 0
    }
}
```

Example event:
```json
{
    "lootEvent": [{
        "items": [
            {
                "amount": "5500",
                "name": "Shrapnel",
                "value": "0.5500"
            },
            {
                "amount": "5500",
                "name": "Shrapnel",
                "value": "0.5500"
            }
        ],
        "date": "2021-11-10 17:41:50"
    }]
}
```
# Images
![image](https://user-images.githubusercontent.com/754107/148544943-fbbb79f5-686f-40d4-a97e-26c88917dac1.png)

![image](https://user-images.githubusercontent.com/754107/148544995-ded211f0-a747-47af-b338-9adb17f9edc3.png)

![image](https://user-images.githubusercontent.com/754107/148545074-c111563b-5ff1-49ed-b588-a81c6e993958.png)

![image](https://user-images.githubusercontent.com/754107/148545027-c2b921c0-2f57-49ed-9908-3c1f213327f3.png)

